### PR TITLE
Add Altcoin Season Index scraper

### DIFF
--- a/altcoin_index_scraper/README.md
+++ b/altcoin_index_scraper/README.md
@@ -1,0 +1,32 @@
+# Altcoin Index Scraper
+
+This directory contains a simple Python script that fetches the Altcoin Season Index from [Blockchain Center](https://www.blockchaincenter.net/en/altcoin-season-index/) once every 24 hours. The value is appended to `data/altcoin_index_history.csv` with an ISO‑8601 timestamp. Logs are written to `logs/scraper.log`.
+
+## Setup
+
+1. Ensure Python 3.9 or newer is installed.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the scraper manually:
+   ```bash
+   python altcoin_index_scraper.py
+   ```
+
+## Scheduling
+
+On Linux, you can run the scraper daily via cron. Example (runs at 03:05 UTC every day):
+
+```cron
+5 3 * * * /usr/bin/python3 /path/to/altcoin_index_scraper/altcoin_index_scraper.py
+```
+
+If using a cloud provider, schedule the script with a job that runs every 24 hours.
+
+## Files
+
+- `altcoin_index_scraper.py` – main script
+- `requirements.txt` – Python dependencies
+- `data/altcoin_index_history.csv` – output CSV (created automatically)
+- `logs/scraper.log` – log file

--- a/altcoin_index_scraper/altcoin_index_scraper.py
+++ b/altcoin_index_scraper/altcoin_index_scraper.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Fetch Altcoin Season Index and append to CSV."""
+import csv
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+import time
+
+import requests
+from bs4 import BeautifulSoup
+
+URL = "https://www.blockchaincenter.net/en/altcoin-season-index/"
+CSV_PATH = Path(__file__).with_parent.joinpath("data", "altcoin_index_history.csv")
+LOG_PATH = Path(__file__).with_parent.joinpath("logs", "scraper.log")
+
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+logging.basicConfig(
+    filename=LOG_PATH,
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+
+def fetch_html(url: str, max_retries: int = 3, timeout: int = 10) -> str:
+    delay = 1
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = requests.get(
+                url,
+                headers={
+                    "User-Agent": (
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/114.0 Safari/537.36"
+                    )
+                },
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return response.text
+        except Exception as exc:
+            logging.warning("Attempt %s failed: %s", attempt, exc)
+            if attempt == max_retries:
+                raise
+            time.sleep(delay)
+            delay *= 2
+
+def extract_value(html: str) -> int:
+    soup = BeautifulSoup(html, "html.parser")
+    div = soup.select_one('div[style*="font-size:88px"]')
+    if div is None:
+        raise ValueError("Target div not found")
+    return int(div.get_text(strip=True))
+
+def append_to_csv(value: int) -> None:
+    CSV_PATH.parent.mkdir(parents=True, exist_ok=True)
+    write_header = not CSV_PATH.exists()
+    with CSV_PATH.open("a", newline="") as fp:
+        writer = csv.writer(fp)
+        if write_header:
+            writer.writerow(["timestamp", "value"])
+        writer.writerow([
+            datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(),
+            value,
+        ])
+
+def main() -> None:
+    logging.info("Scraper started")
+    try:
+        html = fetch_html(URL)
+        value = extract_value(html)
+        append_to_csv(value)
+        logging.info("Scraper finished successfully: %s", value)
+    except Exception as exc:
+        logging.exception("Scraper failed: %s", exc)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/altcoin_index_scraper/requirements.txt
+++ b/altcoin_index_scraper/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.*
+beautifulsoup4==4.*
+python-dotenv==1.*


### PR DESCRIPTION
## Summary
- add Python script to scrape the Altcoin Season Index once per day
- include README instructions and dependency list for the scraper

## Testing
- `python3 -m py_compile altcoin_index_scraper/altcoin_index_scraper.py`
- `python3 altcoin_index_scraper/altcoin_index_scraper.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6863ae46ff5083319ac3bb2a30cc8e71